### PR TITLE
Merge from malloch/mapper-max-pd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ mapout/build
 mapin/build
 *.mxo
 *.pd_darwin
+mapper-osx-max-pd*
+oscmulticast

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # libmapper bindings for MaxMSP and Pure Data
 
-Max and Pure Data (Pd) objects instantiating libmapper devices. Help patches are included for documentation.
+Max and Pure Data (Pd) objects instantiating [libmapper][1] devices. Help patches are included for documentation.
 
 The `mapper` object can be used with both Max and Pd - it encapsulates the functionality of a libmapper device and works as a central hub in your patch by sending and receiving labeled messages from the libmapper network.
 

--- a/help/logolink.maxpat
+++ b/help/logolink.maxpat
@@ -4,7 +4,7 @@
 		"appversion" : 		{
 			"major" : 7,
 			"minor" : 3,
-			"revision" : 3,
+			"revision" : 5,
 			"architecture" : "x86",
 			"modernui" : 1
 		}
@@ -105,18 +105,9 @@
 		"lines" : [ 			{
 				"patchline" : 				{
 					"destination" : [ "obj-30", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-1", 0 ]
 				}
 
-			}
- ],
-		"dependency_cache" : [ 			{
-				"name" : "libmapper_logo_black_512px.png",
-				"bootpath" : "~/Desktop/libmapper-logo",
-				"type" : "PNG ",
-				"implicit" : 1
 			}
  ],
 		"autosave" : 0

--- a/help/map.device.maxhelp
+++ b/help/map.device.maxhelp
@@ -4,7 +4,7 @@
 		"appversion" : 		{
 			"major" : 7,
 			"minor" : 3,
-			"revision" : 3,
+			"revision" : 5,
 			"architecture" : "x86",
 			"modernui" : 1
 		}
@@ -49,7 +49,7 @@
 						"appversion" : 						{
 							"major" : 7,
 							"minor" : 3,
-							"revision" : 3,
+							"revision" : 5,
 							"architecture" : "x86",
 							"modernui" : 1
 						}
@@ -265,7 +265,7 @@
 , 			{
 				"box" : 				{
 					"automouse" : 0,
-					"cols" : 2,
+					"cols" : 1,
 					"colwidth" : 90,
 					"fontface" : 0,
 					"fontname" : "Arial",
@@ -278,7 +278,7 @@
 					"numoutlets" : 4,
 					"outlettype" : [ "list", "", "", "" ],
 					"patching_rect" : [ 30.0, 210.0, 180.0, 183.0 ],
-					"rows" : 7,
+					"rows" : 1,
 					"selmode" : 0,
 					"selsync" : 0,
 					"vscroll" : 0,
@@ -342,9 +342,9 @@
 					"fontsize" : 12.0,
 					"id" : "obj-6",
 					"maxclass" : "newobj",
-					"numinlets" : 1,
+					"numinlets" : 0,
 					"numoutlets" : 1,
-					"outlettype" : [ "list" ],
+					"outlettype" : [ "" ],
 					"patching_rect" : [ 30.0, 90.0, 133.0, 22.0 ],
 					"style" : "",
 					"text" : "map.device my_device"
@@ -453,7 +453,6 @@
 		"lines" : [ 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-10", 0 ]
 				}
@@ -462,7 +461,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-15", 0 ]
 				}
@@ -471,8 +469,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-20", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-21", 0 ]
 				}
 
@@ -480,8 +476,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-23", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-24", 0 ]
 				}
 
@@ -489,8 +483,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-21", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-6", 0 ]
 				}
 
@@ -498,7 +490,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-9", 0 ]
 				}
@@ -507,19 +498,9 @@
  ],
 		"dependency_cache" : [ 			{
 				"name" : "logolink.maxpat",
-				"bootpath" : "~/Documents/Mappers/mapper-max-pd/help",
+				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1
-			}
-, 			{
-				"name" : "libmapper_logo_black_512px.png",
-				"bootpath" : "~/Desktop/libmapper-logo",
-				"type" : "PNG ",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "map.device.mxo",
-				"type" : "iLaX"
 			}
  ],
 		"autosave" : 0

--- a/help/map.in.maxhelp
+++ b/help/map.in.maxhelp
@@ -2,9 +2,11 @@
 	"patcher" : 	{
 		"fileversion" : 1,
 		"appversion" : 		{
-			"major" : 6,
-			"minor" : 0,
-			"revision" : 8
+			"major" : 7,
+			"minor" : 3,
+			"revision" : 5,
+			"architecture" : "x86",
+			"modernui" : 1
 		}
 ,
 		"rect" : [ 688.0, 251.0, 616.0, 443.0 ],
@@ -13,19 +15,27 @@
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
 		"default_fontname" : "Arial",
-		"gridonopen" : 0,
+		"gridonopen" : 1,
 		"gridsize" : [ 15.0, 15.0 ],
-		"gridsnaponopen" : 0,
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
 		"statusbarvisible" : 2,
 		"toolbarvisible" : 1,
+		"lefttoolbarpinned" : 0,
+		"toptoolbarpinned" : 0,
+		"righttoolbarpinned" : 0,
+		"bottomtoolbarpinned" : 0,
+		"toolbars_unpinned_last_save" : 0,
+		"tallnewobj" : 0,
 		"boxanimatetime" : 200,
-		"imprint" : 0,
 		"enablehscroll" : 1,
 		"enablevscroll" : 1,
 		"devicewidth" : 0.0,
 		"description" : "",
 		"digest" : "",
 		"tags" : "",
+		"style" : "",
+		"subpatcher_template" : "",
 		"boxes" : [ 			{
 				"box" : 				{
 					"fontname" : "Arial",
@@ -37,9 +47,11 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 6,
-							"minor" : 0,
-							"revision" : 8
+							"major" : 7,
+							"minor" : 3,
+							"revision" : 5,
+							"architecture" : "x86",
+							"modernui" : 1
 						}
 ,
 						"rect" : [ 777.0, 125.0, 640.0, 480.0 ],
@@ -48,30 +60,40 @@
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 0,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
+						"lefttoolbarpinned" : 0,
+						"toptoolbarpinned" : 0,
+						"righttoolbarpinned" : 0,
+						"bottomtoolbarpinned" : 0,
+						"toolbars_unpinned_last_save" : 0,
+						"tallnewobj" : 0,
 						"boxanimatetime" : 200,
-						"imprint" : 0,
 						"enablehscroll" : 1,
 						"enablevscroll" : 1,
 						"devicewidth" : 0.0,
 						"description" : "",
 						"digest" : "",
 						"tags" : "",
+						"style" : "",
+						"subpatcher_template" : "",
 						"boxes" : [ 							{
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
+									"format" : 6,
 									"id" : "obj-8",
 									"maxclass" : "flonum",
 									"numinlets" : 1,
 									"numoutlets" : 2,
-									"outlettype" : [ "float", "bang" ],
+									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 45.0, 285.0, 50.0, 20.0 ]
+									"patching_rect" : [ 45.0, 285.0, 50.0, 20.0 ],
+									"style" : ""
 								}
 
 							}
@@ -79,14 +101,13 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-5",
 									"linecount" : 4,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 45.0, 210.0, 409.0, 60.0 ],
-									"presentation_rect" : [ 45.0, 213.0, 0.0, 0.0 ],
+									"style" : "",
 									"text" : "Sometimes changes in a signal value will be generated internally to your patch instead of resulting from mapped remote signals. Informing the map.in object of the new value allows it to be queried by other devices on the network, e.g. for training supervised machine learning systems."
 								}
 
@@ -99,10 +120,9 @@
 									"id" : "obj-6",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "list" ],
+									"numoutlets" : 0,
 									"patching_rect" : [ 45.0, 315.0, 289.0, 20.0 ],
-									"presentation_rect" : [ 45.0, 273.0, 0.0, 0.0 ],
+									"style" : "",
 									"text" : "map.in frequency f @unit Hz @min 20 @max 20000"
 								}
 
@@ -111,12 +131,12 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-4",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 30.0, 180.0, 150.0, 20.0 ],
+									"style" : "",
 									"text" : "Setting values:"
 								}
 
@@ -125,12 +145,12 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-2",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 30.0, 45.0, 150.0, 20.0 ],
+									"style" : "",
 									"text" : "Metadata"
 								}
 
@@ -139,13 +159,13 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-24",
 									"linecount" : 3,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 45.0, 75.0, 413.0, 47.0 ],
+									"style" : "",
 									"text" : "Labeling your input with metadata helps with mapping later - for example, if ranges are provided libmapper will perform linear scaling by default on new connections. Feel free to add any metadata you think might be useful."
 								}
 
@@ -157,10 +177,10 @@
 									"fontsize" : 12.0,
 									"id" : "obj-21",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "list" ],
+									"numinlets" : 0,
+									"numoutlets" : 0,
 									"patching_rect" : [ 45.0, 135.0, 289.0, 20.0 ],
+									"style" : "",
 									"text" : "map.in frequency f @unit Hz @min 20 @max 20000"
 								}
 
@@ -169,8 +189,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -178,20 +196,16 @@
  ]
 					}
 ,
-					"patching_rect" : [ 30.0, 225.0, 48.0, 20.0 ],
+					"patching_rect" : [ 30.0, 225.0, 48.0, 22.0 ],
 					"saved_object_attributes" : 					{
-						"default_fontface" : 0,
-						"default_fontname" : "Arial",
-						"default_fontsize" : 12.0,
 						"description" : "",
 						"digest" : "",
-						"fontface" : 0,
-						"fontname" : "Arial",
-						"fontsize" : 12.0,
 						"globalpatchername" : "",
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p more"
 				}
 
@@ -204,10 +218,10 @@
 					"maxclass" : "number",
 					"numinlets" : 1,
 					"numoutlets" : 2,
-					"outlettype" : [ "int", "bang" ],
+					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 120.0, 165.0, 50.0, 20.0 ],
-					"presentation_rect" : [ 124.0, 165.0, 0.0, 0.0 ]
+					"patching_rect" : [ 120.0, 165.0, 50.0, 22.0 ],
+					"style" : ""
 				}
 
 			}
@@ -215,14 +229,15 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
+					"format" : 6,
 					"id" : "obj-26",
 					"maxclass" : "flonum",
 					"numinlets" : 1,
 					"numoutlets" : 2,
-					"outlettype" : [ "float", "bang" ],
+					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 30.0, 165.0, 50.0, 20.0 ],
-					"presentation_rect" : [ 34.0, 165.0, 0.0, 0.0 ]
+					"patching_rect" : [ 30.0, 165.0, 50.0, 22.0 ],
+					"style" : ""
 				}
 
 			}
@@ -233,10 +248,11 @@
 					"fontsize" : 12.0,
 					"id" : "obj-13",
 					"maxclass" : "newobj",
-					"numinlets" : 1,
+					"numinlets" : 0,
 					"numoutlets" : 1,
-					"outlettype" : [ "list" ],
-					"patching_rect" : [ 120.0, 135.0, 73.0, 20.0 ],
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 120.0, 135.0, 73.0, 22.0 ],
+					"style" : "",
 					"text" : "map.in bar i"
 				}
 
@@ -245,13 +261,13 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-11",
 					"linecount" : 5,
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 30.0, 315.0, 156.0, 74.0 ],
+					"style" : "",
 					"text" : "There needs to be a map.device object somewhere in the patcher. It will also bind to map.in objects in subpatchers"
 				}
 
@@ -263,10 +279,11 @@
 					"fontsize" : 12.0,
 					"id" : "obj-1",
 					"maxclass" : "newobj",
-					"numinlets" : 1,
+					"numinlets" : 0,
 					"numoutlets" : 1,
-					"outlettype" : [ "list" ],
-					"patching_rect" : [ 30.0, 135.0, 73.0, 20.0 ],
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 135.0, 73.0, 22.0 ],
+					"style" : "",
 					"text" : "map.in foo f"
 				}
 
@@ -275,12 +292,12 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-18",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 240.0, 315.0, 60.0, 20.0 ],
+					"style" : "",
 					"text" : "see also:"
 				}
 
@@ -294,7 +311,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 240.0, 374.5, 72.0, 18.0 ],
+					"patching_rect" : [ 240.0, 374.5, 72.0, 22.0 ],
+					"style" : "",
 					"text" : "map.device"
 				}
 
@@ -310,6 +328,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 240.0, 433.0, 59.0, 20.0 ],
+					"style" : "",
 					"text" : "pcontrol"
 				}
 
@@ -325,6 +344,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 240.0, 403.0, 86.0, 20.0 ],
+					"style" : "",
 					"text" : "prepend help"
 				}
 
@@ -338,7 +358,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 240.0, 345.0, 54.0, 18.0 ],
+					"patching_rect" : [ 240.0, 345.0, 54.0, 22.0 ],
+					"style" : "",
 					"text" : "map.out"
 				}
 
@@ -347,13 +368,13 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-8",
 					"linecount" : 4,
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 270.0, 125.0, 288.0, 60.0 ],
+					"style" : "",
 					"text" : "The map.in object creates a discoverable, dynamically-mappable input in your patch. Click the logo below to visit libmapper.org and learn more about these tools."
 				}
 
@@ -365,10 +386,10 @@
 					"fontsize" : 12.0,
 					"id" : "obj-6",
 					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "list" ],
-					"patching_rect" : [ 30.0, 389.0, 72.0, 20.0 ],
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 389.0, 72.0, 22.0 ],
+					"style" : "",
 					"text" : "map.device"
 				}
 
@@ -377,25 +398,33 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-3",
 					"linecount" : 3,
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 365.0, 330.0, 85.0, 47.0 ],
+					"style" : "",
 					"text" : "For more information click here ->"
 				}
 
 			}
 , 			{
 				"box" : 				{
+					"bgmode" : 0,
+					"border" : 0,
+					"clickthrough" : 0,
+					"enablehscroll" : 0,
+					"enablevscroll" : 0,
 					"id" : "obj-64",
+					"lockeddragscroll" : 0,
 					"maxclass" : "bpatcher",
 					"name" : "logolink.maxpat",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 450.0, 267.5, 150.0, 155.5 ]
+					"offset" : [ 0.0, 0.0 ],
+					"patching_rect" : [ 450.0, 267.5, 150.0, 155.5 ],
+					"viewvisibility" : 1
 				}
 
 			}
@@ -403,12 +432,12 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 14.0,
-					"frgb" : 0.0,
 					"id" : "obj-16",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 15.0, 45.0, 484.0, 22.0 ],
+					"style" : "",
 					"text" : "A MaxMSP wrapper for a libmapper input signal"
 				}
 
@@ -418,12 +447,12 @@
 					"fontface" : 3,
 					"fontname" : "Arial",
 					"fontsize" : 20.871338,
-					"frgb" : 0.0,
 					"id" : "obj-22",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 15.0, 15.0, 485.0, 30.0 ],
+					"style" : "",
 					"text" : "map.in",
 					"textcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 					"varname" : "autohelp_top_title"
@@ -432,12 +461,16 @@
 			}
 , 			{
 				"box" : 				{
+					"angle" : 0.0,
 					"bgcolor" : [ 0.0, 0.0, 0.0, 1.0 ],
 					"id" : "obj-60",
 					"maxclass" : "panel",
+					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 576.0, 15.0, 4.0, 304.0 ]
+					"patching_rect" : [ 576.0, 15.0, 4.0, 304.0 ],
+					"proportion" : 0.39,
+					"style" : ""
 				}
 
 			}
@@ -453,6 +486,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 15.0, 15.0, 565.0, 30.0 ],
+					"proportion" : 0.39,
+					"style" : "",
 					"varname" : "autohelp_top_panel[1]"
 				}
 
@@ -461,8 +496,6 @@
 		"lines" : [ 			{
 				"patchline" : 				{
 					"destination" : [ "obj-26", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-1", 0 ]
 				}
 
@@ -470,7 +503,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-10", 0 ]
 				}
@@ -479,8 +511,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-25", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-13", 0 ]
 				}
 
@@ -488,7 +518,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-15", 0 ]
 				}
@@ -497,7 +526,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-9", 0 ]
 				}
@@ -506,20 +534,12 @@
  ],
 		"dependency_cache" : [ 			{
 				"name" : "logolink.maxpat",
-				"bootpath" : "/Users/jocal/Documents/Mappers/mapper-max-pd",
-				"patcherrelativepath" : "",
+				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1
 			}
-, 			{
-				"name" : "map.device.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "map.in.mxo",
-				"type" : "iLaX"
-			}
- ]
+ ],
+		"autosave" : 0
 	}
 
 }

--- a/help/map.out.maxhelp
+++ b/help/map.out.maxhelp
@@ -2,9 +2,11 @@
 	"patcher" : 	{
 		"fileversion" : 1,
 		"appversion" : 		{
-			"major" : 6,
-			"minor" : 0,
-			"revision" : 8
+			"major" : 7,
+			"minor" : 3,
+			"revision" : 5,
+			"architecture" : "x86",
+			"modernui" : 1
 		}
 ,
 		"rect" : [ 161.0, 182.0, 616.0, 443.0 ],
@@ -13,19 +15,27 @@
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
 		"default_fontname" : "Arial",
-		"gridonopen" : 0,
+		"gridonopen" : 1,
 		"gridsize" : [ 15.0, 15.0 ],
-		"gridsnaponopen" : 0,
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
 		"statusbarvisible" : 2,
 		"toolbarvisible" : 1,
+		"lefttoolbarpinned" : 0,
+		"toptoolbarpinned" : 0,
+		"righttoolbarpinned" : 0,
+		"bottomtoolbarpinned" : 0,
+		"toolbars_unpinned_last_save" : 0,
+		"tallnewobj" : 0,
 		"boxanimatetime" : 200,
-		"imprint" : 0,
 		"enablehscroll" : 1,
 		"enablevscroll" : 1,
 		"devicewidth" : 0.0,
 		"description" : "",
 		"digest" : "",
 		"tags" : "",
+		"style" : "",
+		"subpatcher_template" : "",
 		"boxes" : [ 			{
 				"box" : 				{
 					"fontname" : "Arial",
@@ -37,9 +47,11 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 6,
-							"minor" : 0,
-							"revision" : 8
+							"major" : 7,
+							"minor" : 3,
+							"revision" : 5,
+							"architecture" : "x86",
+							"modernui" : 1
 						}
 ,
 						"rect" : [ 777.0, 125.0, 640.0, 480.0 ],
@@ -48,19 +60,27 @@
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 0,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
+						"lefttoolbarpinned" : 0,
+						"toptoolbarpinned" : 0,
+						"righttoolbarpinned" : 0,
+						"bottomtoolbarpinned" : 0,
+						"toolbars_unpinned_last_save" : 0,
+						"tallnewobj" : 0,
 						"boxanimatetime" : 200,
-						"imprint" : 0,
 						"enablehscroll" : 1,
 						"enablevscroll" : 1,
 						"devicewidth" : 0.0,
 						"description" : "",
 						"digest" : "",
 						"tags" : "",
+						"style" : "",
+						"subpatcher_template" : "",
 						"boxes" : [ 							{
 								"box" : 								{
 									"fontname" : "Arial",
@@ -71,6 +91,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 45.0, 285.0, 41.0, 18.0 ],
+									"style" : "",
 									"text" : "query"
 								}
 
@@ -79,14 +100,15 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
+									"format" : 6,
 									"id" : "obj-1",
 									"maxclass" : "flonum",
 									"numinlets" : 1,
 									"numoutlets" : 2,
-									"outlettype" : [ "float", "bang" ],
+									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
 									"patching_rect" : [ 45.0, 345.0, 50.0, 20.0 ],
-									"presentation_rect" : [ 47.0, 348.0, 0.0, 0.0 ]
+									"style" : ""
 								}
 
 							}
@@ -94,13 +116,13 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-5",
 									"linecount" : 4,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 45.0, 210.0, 409.0, 60.0 ],
+									"style" : "",
 									"text" : "Sometimes you might want to discover the values of remote inputs that are connected to this output, e.g. for training supervised machine learning systems. Just send the message \"query\" to the map.out object and it will query the values any connected signals and output them from its outlet."
 								}
 
@@ -114,8 +136,9 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 1,
-									"outlettype" : [ "list" ],
+									"outlettype" : [ "" ],
 									"patching_rect" : [ 45.0, 315.0, 296.0, 20.0 ],
+									"style" : "",
 									"text" : "map.out frequency f @unit Hz @min 20 @max 20000"
 								}
 
@@ -124,12 +147,12 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-4",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 30.0, 180.0, 150.0, 20.0 ],
+									"style" : "",
 									"text" : "Querying remote values:"
 								}
 
@@ -138,12 +161,12 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-2",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 30.0, 45.0, 150.0, 20.0 ],
+									"style" : "",
 									"text" : "Metadata"
 								}
 
@@ -152,13 +175,13 @@
 								"box" : 								{
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
-									"frgb" : 0.0,
 									"id" : "obj-24",
 									"linecount" : 3,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 45.0, 75.0, 409.0, 47.0 ],
+									"style" : "",
 									"text" : "Labeling your output with metadata helps with mapping later - for example, if ranges are provided libmapper will perform linear scaling by default on new connections. Feel free to add any metadata you think might be useful."
 								}
 
@@ -170,10 +193,10 @@
 									"fontsize" : 12.0,
 									"id" : "obj-21",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "list" ],
+									"numinlets" : 0,
+									"numoutlets" : 0,
 									"patching_rect" : [ 45.0, 135.0, 296.0, 20.0 ],
+									"style" : "",
 									"text" : "map.out frequency f @unit Hz @min 20 @max 20000"
 								}
 
@@ -182,8 +205,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -191,8 +212,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -200,20 +219,16 @@
  ]
 					}
 ,
-					"patching_rect" : [ 30.0, 225.0, 48.0, 20.0 ],
+					"patching_rect" : [ 30.0, 225.0, 48.0, 22.0 ],
 					"saved_object_attributes" : 					{
-						"default_fontface" : 0,
-						"default_fontname" : "Arial",
-						"default_fontsize" : 12.0,
 						"description" : "",
 						"digest" : "",
-						"fontface" : 0,
-						"fontname" : "Arial",
-						"fontsize" : 12.0,
 						"globalpatchername" : "",
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p more"
 				}
 
@@ -226,9 +241,10 @@
 					"maxclass" : "number",
 					"numinlets" : 1,
 					"numoutlets" : 2,
-					"outlettype" : [ "int", "bang" ],
+					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 120.0, 135.0, 50.0, 20.0 ]
+					"patching_rect" : [ 120.0, 135.0, 50.0, 22.0 ],
+					"style" : ""
 				}
 
 			}
@@ -240,9 +256,9 @@
 					"id" : "obj-13",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "list" ],
-					"patching_rect" : [ 120.0, 165.0, 81.0, 20.0 ],
+					"numoutlets" : 0,
+					"patching_rect" : [ 120.0, 165.0, 81.0, 22.0 ],
+					"style" : "",
 					"text" : "map.out bar i"
 				}
 
@@ -251,13 +267,13 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-11",
 					"linecount" : 5,
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 30.0, 315.0, 156.0, 74.0 ],
+					"style" : "",
 					"text" : "There needs to be a map.device object somewhere in the patcher. It will also bind to map.out objects in subpatchers"
 				}
 
@@ -266,13 +282,15 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
+					"format" : 6,
 					"id" : "obj-5",
 					"maxclass" : "flonum",
 					"numinlets" : 1,
 					"numoutlets" : 2,
-					"outlettype" : [ "float", "bang" ],
+					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 30.0, 135.0, 50.0, 20.0 ]
+					"patching_rect" : [ 30.0, 135.0, 50.0, 22.0 ],
+					"style" : ""
 				}
 
 			}
@@ -284,9 +302,9 @@
 					"id" : "obj-1",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "list" ],
-					"patching_rect" : [ 30.0, 165.0, 81.0, 20.0 ],
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 165.0, 81.0, 22.0 ],
+					"style" : "",
 					"text" : "map.out foo f"
 				}
 
@@ -295,12 +313,12 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-18",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 240.0, 315.0, 60.0, 20.0 ],
+					"style" : "",
 					"text" : "see also:"
 				}
 
@@ -314,7 +332,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 240.0, 374.5, 72.0, 18.0 ],
+					"patching_rect" : [ 240.0, 374.5, 72.0, 22.0 ],
+					"style" : "",
 					"text" : "map.device"
 				}
 
@@ -330,6 +349,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 240.0, 433.0, 59.0, 20.0 ],
+					"style" : "",
 					"text" : "pcontrol"
 				}
 
@@ -345,6 +365,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 240.0, 403.0, 86.0, 20.0 ],
+					"style" : "",
 					"text" : "prepend help"
 				}
 
@@ -358,7 +379,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 240.0, 345.0, 47.0, 18.0 ],
+					"patching_rect" : [ 240.0, 345.0, 47.0, 22.0 ],
+					"style" : "",
 					"text" : "map.in"
 				}
 
@@ -367,13 +389,13 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-8",
 					"linecount" : 4,
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 270.0, 125.0, 273.0, 60.0 ],
+					"style" : "",
 					"text" : "The map.out object creates a discoverable, dynamically-mappable output in your patch. Click the logo below to visit libmapper.org and learn more about these tools."
 				}
 
@@ -385,10 +407,10 @@
 					"fontsize" : 12.0,
 					"id" : "obj-6",
 					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "list" ],
-					"patching_rect" : [ 30.0, 389.0, 72.0, 20.0 ],
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 389.0, 72.0, 22.0 ],
+					"style" : "",
 					"text" : "map.device"
 				}
 
@@ -397,25 +419,33 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 12.0,
-					"frgb" : 0.0,
 					"id" : "obj-3",
 					"linecount" : 3,
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 365.0, 330.0, 85.0, 47.0 ],
+					"style" : "",
 					"text" : "For more information click here ->"
 				}
 
 			}
 , 			{
 				"box" : 				{
+					"bgmode" : 0,
+					"border" : 0,
+					"clickthrough" : 0,
+					"enablehscroll" : 0,
+					"enablevscroll" : 0,
 					"id" : "obj-64",
+					"lockeddragscroll" : 0,
 					"maxclass" : "bpatcher",
 					"name" : "logolink.maxpat",
 					"numinlets" : 0,
 					"numoutlets" : 0,
-					"patching_rect" : [ 450.0, 267.5, 150.0, 155.5 ]
+					"offset" : [ 0.0, 0.0 ],
+					"patching_rect" : [ 450.0, 267.5, 150.0, 155.5 ],
+					"viewvisibility" : 1
 				}
 
 			}
@@ -423,12 +453,12 @@
 				"box" : 				{
 					"fontname" : "Arial",
 					"fontsize" : 14.0,
-					"frgb" : 0.0,
 					"id" : "obj-16",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 15.0, 45.0, 484.0, 22.0 ],
+					"style" : "",
 					"text" : "A MaxMSP wrapper for a libmapper output signal"
 				}
 
@@ -438,12 +468,12 @@
 					"fontface" : 3,
 					"fontname" : "Arial",
 					"fontsize" : 20.871338,
-					"frgb" : 0.0,
 					"id" : "obj-22",
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 15.0, 15.0, 485.0, 30.0 ],
+					"style" : "",
 					"text" : "map.out",
 					"textcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 					"varname" : "autohelp_top_title"
@@ -452,12 +482,16 @@
 			}
 , 			{
 				"box" : 				{
+					"angle" : 0.0,
 					"bgcolor" : [ 0.0, 0.0, 0.0, 1.0 ],
 					"id" : "obj-60",
 					"maxclass" : "panel",
+					"mode" : 0,
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 576.0, 15.0, 4.0, 304.0 ]
+					"patching_rect" : [ 576.0, 15.0, 4.0, 304.0 ],
+					"proportion" : 0.39,
+					"style" : ""
 				}
 
 			}
@@ -473,6 +507,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 15.0, 15.0, 565.0, 30.0 ],
+					"proportion" : 0.39,
+					"style" : "",
 					"varname" : "autohelp_top_panel[1]"
 				}
 
@@ -481,7 +517,6 @@
 		"lines" : [ 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-10", 0 ]
 				}
@@ -490,7 +525,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-15", 0 ]
 				}
@@ -499,8 +533,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-13", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-19", 0 ]
 				}
 
@@ -508,8 +540,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-1", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-5", 0 ]
 				}
 
@@ -517,7 +547,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
-					"disabled" : 0,
 					"hidden" : 1,
 					"source" : [ "obj-9", 0 ]
 				}
@@ -526,20 +555,12 @@
  ],
 		"dependency_cache" : [ 			{
 				"name" : "logolink.maxpat",
-				"bootpath" : "/Users/jocal/Documents/Mappers/mapper-max-pd",
-				"patcherrelativepath" : "",
+				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1
 			}
-, 			{
-				"name" : "map.device.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "map.out.mxo",
-				"type" : "iLaX"
-			}
- ]
+ ],
+		"autosave" : 0
 	}
 
 }

--- a/help/mapper.maxhelp
+++ b/help/mapper.maxhelp
@@ -4,7 +4,7 @@
 		"appversion" : 		{
 			"major" : 7,
 			"minor" : 3,
-			"revision" : 3,
+			"revision" : 5,
 			"architecture" : "x86",
 			"modernui" : 1
 		}
@@ -49,7 +49,7 @@
 						"appversion" : 						{
 							"major" : 7,
 							"minor" : 3,
-							"revision" : 3,
+							"revision" : 5,
 							"architecture" : "x86",
 							"modernui" : 1
 						}
@@ -134,8 +134,7 @@
 									"id" : "obj-3",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "list", "list" ],
+									"numoutlets" : 0,
 									"patching_rect" : [ 60.0, 285.0, 51.0, 22.0 ],
 									"style" : "",
 									"text" : "mapper"
@@ -161,8 +160,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -170,8 +167,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 204.5, 271.0, 69.5, 271.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
@@ -180,8 +175,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -220,7 +213,7 @@
 			}
 , 			{
 				"box" : 				{
-					"cols" : 2,
+					"cols" : 1,
 					"colwidth" : 90,
 					"fontface" : 0,
 					"fontname" : "Arial",
@@ -232,7 +225,7 @@
 					"numoutlets" : 4,
 					"outlettype" : [ "list", "", "", "" ],
 					"patching_rect" : [ 30.0, 180.0, 180.0, 90.0 ],
-					"rows" : 7,
+					"rows" : 1,
 					"vscroll" : 0
 				}
 
@@ -299,7 +292,7 @@
 						"appversion" : 						{
 							"major" : 7,
 							"minor" : 3,
-							"revision" : 3,
+							"revision" : 5,
 							"architecture" : "x86",
 							"modernui" : 1
 						}
@@ -352,9 +345,8 @@
 									"fontsize" : 12.0,
 									"id" : "obj-3",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "list", "list" ],
+									"numinlets" : 0,
+									"numoutlets" : 0,
 									"patching_rect" : [ 60.0, 165.0, 233.0, 22.0 ],
 									"style" : "",
 									"text" : "mapper @alias foo @definition tester.json"
@@ -407,7 +399,7 @@
 						"appversion" : 						{
 							"major" : 7,
 							"minor" : 3,
-							"revision" : 3,
+							"revision" : 5,
 							"architecture" : "x86",
 							"modernui" : 1
 						}
@@ -500,13 +492,13 @@
 									"fontname" : "Arial",
 									"fontsize" : 12.0,
 									"id" : "obj-20",
-									"linecount" : 6,
+									"linecount" : 4,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 90.0, 300.0, 150.0, 87.0 ],
+									"patching_rect" : [ 90.0, 300.0, 174.0, 60.0 ],
 									"style" : "",
-									"text" : "Sends the /link and /connect messages which create a mapping connection between the two instances of the mapper object"
+									"text" : "Send the /map message to create a connection between the two instances of the mapper object."
 								}
 
 							}
@@ -545,9 +537,9 @@
 									"fontsize" : 12.0,
 									"id" : "obj-11",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
+									"numinlets" : 0,
 									"numoutlets" : 2,
-									"outlettype" : [ "list", "list" ],
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 30.0, 150.0, 141.0, 22.0 ],
 									"style" : "",
 									"text" : "mapper @def tester.json"
@@ -562,7 +554,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 2,
-									"outlettype" : [ "list", "list" ],
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 30.0, 105.0, 141.0, 22.0 ],
 									"style" : "",
 									"text" : "mapper @def tester.json"
@@ -664,8 +656,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -673,8 +663,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-8", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -682,8 +670,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -691,8 +677,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 161.5, 182.0, 309.5, 182.0 ],
 									"source" : [ "obj-11", 1 ]
 								}
@@ -701,8 +685,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -710,8 +692,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 1 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-2", 0 ]
 								}
 
@@ -719,8 +699,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 1 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-4", 1 ]
 								}
 
@@ -728,8 +706,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -737,8 +713,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -746,8 +720,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -755,8 +727,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -764,8 +734,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 161.5, 137.0, 264.5, 137.0 ],
 									"source" : [ "obj-9", 1 ]
 								}
@@ -801,7 +769,7 @@
 						"appversion" : 						{
 							"major" : 7,
 							"minor" : 3,
-							"revision" : 3,
+							"revision" : 5,
 							"architecture" : "x86",
 							"modernui" : 1
 						}
@@ -926,8 +894,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-2", 0 ]
 								}
 
@@ -935,8 +901,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -944,8 +908,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -953,8 +915,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -989,7 +949,7 @@
 						"appversion" : 						{
 							"major" : 7,
 							"minor" : 3,
-							"revision" : 3,
+							"revision" : 5,
 							"architecture" : "x86",
 							"modernui" : 1
 						}
@@ -1250,7 +1210,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 2,
-									"outlettype" : [ "list", "list" ],
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 30.0, 300.0, 124.0, 22.0 ],
 									"style" : "",
 									"text" : "mapper"
@@ -1261,8 +1221,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-1", 1 ]
 								}
 
@@ -1270,8 +1228,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-19", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"order" : 2,
 									"source" : [ "obj-10", 0 ]
 								}
@@ -1280,8 +1236,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-20", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 39.5, 107.0, 129.5, 107.0 ],
 									"order" : 1,
 									"source" : [ "obj-10", 0 ]
@@ -1291,8 +1245,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 39.5, 107.0, 219.5, 107.0 ],
 									"order" : 0,
 									"source" : [ "obj-10", 0 ]
@@ -1302,8 +1254,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -1311,8 +1261,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-16", 0 ]
 								}
 
@@ -1320,8 +1268,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-23", 1 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 39.5, 152.0, 83.5, 152.0 ],
 									"source" : [ "obj-19", 0 ]
 								}
@@ -1330,8 +1276,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 1 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 129.5, 152.0, 173.5, 152.0 ],
 									"source" : [ "obj-20", 0 ]
 								}
@@ -1340,8 +1284,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-25", 1 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 219.5, 152.0, 263.5, 152.0 ],
 									"source" : [ "obj-21", 0 ]
 								}
@@ -1350,8 +1292,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-23", 0 ]
 								}
 
@@ -1359,8 +1299,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 129.5, 197.0, 39.5, 197.0 ],
 									"source" : [ "obj-24", 0 ]
 								}
@@ -1369,8 +1307,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"midpoints" : [ 219.5, 197.0, 39.5, 197.0 ],
 									"source" : [ "obj-25", 0 ]
 								}
@@ -1379,8 +1315,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -1388,8 +1322,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"disabled" : 0,
-									"hidden" : 0,
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -1434,7 +1366,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 2,
-					"outlettype" : [ "list", "list" ],
+					"outlettype" : [ "", "" ],
 					"patching_rect" : [ 30.0, 120.0, 214.0, 22.0 ],
 					"style" : "",
 					"text" : "mapper @alias my_device"
@@ -1543,8 +1475,6 @@
 		"lines" : [ 			{
 				"patchline" : 				{
 					"destination" : [ "obj-6", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-1", 0 ]
 				}
 
@@ -1552,8 +1482,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-20", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-21", 0 ]
 				}
 
@@ -1561,8 +1489,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-23", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-24", 0 ]
 				}
 
@@ -1570,8 +1496,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-21", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-6", 1 ]
 				}
 
@@ -1579,19 +1503,9 @@
  ],
 		"dependency_cache" : [ 			{
 				"name" : "logolink.maxpat",
-				"bootpath" : "~/Documents/Mappers/mapper-max-pd/help",
+				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1
-			}
-, 			{
-				"name" : "libmapper_logo_black_512px.png",
-				"bootpath" : "~/Desktop/libmapper-logo",
-				"type" : "PNG ",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "mapper.mxo",
-				"type" : "iLaX"
 			}
 , 			{
 				"name" : "oscmulticast.mxo",

--- a/mapdevice/map.device.c
+++ b/mapdevice/map.device.c
@@ -221,7 +221,6 @@ static void *mapdevice_new(t_symbol *s, int argc, t_atom *argv)
             }
         }
 
-        mapdevice_print_properties(x);
         x->ready = 0;
         x->updated = 0;
 
@@ -640,7 +639,7 @@ static void mapdevice_poll(t_mapdevice *x)
             if (!mapper_device_num_signals(x->device, MAPPER_DIR_ANY))
                 object_post((t_object *)x, "Waiting for inputs and outputs...");
             x->ready = 1;
-            mapdevice_print_properties(x);
+            defer_low((t_object *)x, (method)mapdevice_print_properties, NULL, 0, NULL);
         }
     }
     else if (x->updated) {

--- a/mapdevice/map.device.xcodeproj/project.pbxproj
+++ b/mapdevice/map.device.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);

--- a/mapdevice/map.device.xcodeproj/project.pbxproj
+++ b/mapdevice/map.device.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				C74SUPPORT = "/Applications/MaxSDK-7.1.0/source/c74support";
+				C74SUPPORT = "/Applications/max-sdk-7.3.3/source/c74support";
 				C74_SYM_LINKER_FLAGS = "@$(C74SUPPORT)/max-includes/c74_linker_flags.txt";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/mapin/map.in.xcodeproj/project.pbxproj
+++ b/mapin/map.in.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				C74SUPPORT = "/Applications/MaxSDK-7.1.0/source/c74support";
+				C74SUPPORT = "/Applications/max-sdk-7.3.3/source/c74support";
 				C74_SYM_LINKER_FLAGS = "@$(C74SUPPORT)/max-includes/c74_linker_flags.txt";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;

--- a/mapin/map.in.xcodeproj/project.pbxproj
+++ b/mapin/map.in.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);

--- a/mapout/map.out.xcodeproj/project.pbxproj
+++ b/mapout/map.out.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				C74SUPPORT = "/Applications/MaxSDK-7.1.0/source/c74support";
+				C74SUPPORT = "/Applications/max-sdk-7.3.3/source/c74support";
 				C74_SYM_LINKER_FLAGS = "@$(C74SUPPORT)/max-includes/c74_linker_flags.txt";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;

--- a/mapout/map.out.xcodeproj/project.pbxproj
+++ b/mapout/map.out.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);

--- a/mapper/makefile
+++ b/mapper/makefile
@@ -110,8 +110,8 @@ LIBMAPPER_CFLAGS = $(shell pkg-config --cflags libmapper)
 LIBMAPPER_LIBS = $(shell pkg-config --libs libmapper)
 
 .c.pd_darwin:
-	$(CC) -arch i386 $(DARWINCFLAGS) $(LINUXINCLUDE) -I /Applications/Pd-extended.app/Contents/Resources/include -o $*.o -c $*.c $(LIBMAPPER_CFLAGS)
-	$(CC) -arch i386 -bundle -undefined suppress -flat_namespace \
+	$(CC) -arch i386 -arch x86_64 $(DARWINCFLAGS) $(LINUXINCLUDE) -I /Applications/Pd-extended.app/Contents/Resources/include -o $*.o -c $*.c $(LIBMAPPER_CFLAGS)
+	$(CC) -arch i386 -arch x86_64 -bundle -undefined suppress -flat_namespace \
 	    -o $*.pd_darwin $*.o $(LIBMAPPER_LIBS)
 	rm -f $*.o
 

--- a/mapper/mapper.c
+++ b/mapper/mapper.c
@@ -290,7 +290,6 @@ static void *mapperobj_new(t_symbol *s, int argc, t_atom *argv)
             }
         }
 
-        mapperobj_print_properties(x);
         x->ready = 0;
         x->updated = 0;
         x->learn_mode = learn;
@@ -1222,7 +1221,7 @@ static void mapperobj_poll(t_mapper *x)
         if (mapper_device_ready(x->device)) {
             POST(x, "Joining mapping network as '%s'", mapper_device_name(x->device));
             x->ready = 1;
-            mapperobj_print_properties(x);
+            defer_low((t_object *)x, (method)mapperobj_print_properties, NULL, 0, NULL);
         }
     }
     else if (x->updated) {

--- a/mapper/mapper.c
+++ b/mapper/mapper.c
@@ -1221,7 +1221,11 @@ static void mapperobj_poll(t_mapper *x)
         if (mapper_device_ready(x->device)) {
             POST(x, "Joining mapping network as '%s'", mapper_device_name(x->device));
             x->ready = 1;
+#ifdef MAXMSP
             defer_low((t_object *)x, (method)mapperobj_print_properties, NULL, 0, NULL);
+#else
+            mapperobj_print_properties(x);
+#endif
         }
     }
     else if (x->updated) {

--- a/mapper/mapper.xcodeproj/project.pbxproj
+++ b/mapper/mapper.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(C74_SYM_LINKER_FLAGS)",
+					/usr/local/lib/liblo.dylib,
 					"-lmx",
 					/usr/local/lib/libmapper.dylib,
 				);

--- a/mapper/mapper.xcodeproj/project.pbxproj
+++ b/mapper/mapper.xcodeproj/project.pbxproj
@@ -170,7 +170,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				C74SUPPORT = "/Applications/MaxSDK-7.1.0/source/c74support";
+				C74SUPPORT = "/Applications/max-sdk-7.3.3/source/c74support";
 				C74_SYM_LINKER_FLAGS = "@$(C74SUPPORT)/max-includes/c74_linker_flags.txt";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/package-osx.sh
+++ b/package-osx.sh
@@ -39,7 +39,6 @@ cp ./mapper/tester.json ./mapper-osx-max-pd/old_bindings/
 cp ./help/mapper.maxhelp ./mapper-osx-max-pd/old_bindings/
 cp ./mapper/mapper.pd_darwin ./mapper-osx-max-pd/old_bindings/
 cp ./help/mapper.help.pd ./mapper-osx-max-pd/old_bindings/
-cp -r ./oscmulticast/oscmulticast.mxo ./mapper-osx-max-pd/old_bindings/
 
 mv ./mapdevice/build/maxmsp/map.device.mxo ./mapper-osx-max-pd/new_bindings/
 cp ./help/map.device.maxhelp ./mapper-osx-max-pd/new_bindings/
@@ -62,5 +61,9 @@ echo copying dylibs...
 ./dylibbundler/dylibbundler -cd -b -p '@loader_path/../libs/' -x ./mapper-osx-max-pd/new_bindings/map.in.mxo/Contents/MacOS/map.in -d ./mapper-osx-max-pd/new_bindings/map.in.mxo/Contents/libs/
 
 ./dylibbundler/dylibbundler -cd -b -p '@loader_path/../libs/' -x ./mapper-osx-max-pd/new_bindings/map.out.mxo/Contents/MacOS/map.out -d ./mapper-osx-max-pd/new_bindings/map.out.mxo/Contents/libs/
+
+./dylibbundler/dylibbundler -cd -b -p '@loader_path/../libs/' -x ./mapper-osx-max-pd/oscmulticast/oscmulticast.mxo/Contents/MacOS/oscmulticast -d ./mapper-osx-max-pd/oscmulticast/oscmulticast.mxo/Contents/libs/
+
+cp -r ./mapper-osx-max-pd/oscmulticast/oscmulticast.mxo ./mapper-osx-max-pd/old_bindings/
 
 echo Done.


### PR DESCRIPTION
- Max SDK update
- Restored explicit linking to liblo dylib in xcodeproj
- Pd mapper object removed Max-specific function call
- fat binary for Pd object in makefile
- dylibbundler processing for oscmulticast in package_osx.sh