### PR TITLE
Vs2017 dev

### DIFF
--- a/mpr_device/mpr.device.c
+++ b/mpr_device/mpr.device.c
@@ -14,6 +14,10 @@
 // *********************************************************
 // -(Includes)----------------------------------------------
 
+#ifdef WIN32
+#define _WINSOCKAPI_ //for winsock1/2 conflicts
+#endif
+
 #include "ext.h"            // standard Max include, always required
 #include "ext_obex.h"       // required for new style Max object
 #include "ext_critical.h"
@@ -25,9 +29,10 @@
 #include <math.h>
 #ifndef WIN32
   #include <arpa/inet.h>
+  #include <unistd.h>
 #endif
 
-#include <unistd.h>
+
 
 #define INTERVAL 1
 #define MAX_LIST 256
@@ -96,6 +101,14 @@ static void atom_set_string(t_atom *a, const char *string);
 static void *mpr_device_class;
 
 // *********************************************************
+
+#ifdef WIN32
+void ext_main(void* r)
+{
+	main();
+}
+#endif
+
 // -(main)--------------------------------------------------
 int main(void)
 {

--- a/mpr_in/mpr.in.c
+++ b/mpr_in/mpr.in.c
@@ -14,6 +14,10 @@
 // *********************************************************
 // -(Includes)----------------------------------------------
 
+#ifdef WIN32
+#define _WINSOCKAPI_ //for winsock1/2 conflicts
+#endif
+
 #include "ext.h"            // standard Max include, always required
 #include "ext_obex.h"       // required for new style Max object
 #include "ext_critical.h"
@@ -25,9 +29,9 @@
 #include <math.h>
 #ifndef WIN32
   #include <arpa/inet.h>
+  #include <unistd.h>
 #endif
 
-#include <unistd.h>
 
 #define MAX_LIST 256
 
@@ -90,6 +94,13 @@ static float atom_coerce_float(t_atom *a);
 static void *mpr_in_class;
 
 // *********************************************************
+#ifdef WIN32
+void ext_main(void *r)
+{
+    main();
+}
+#endif
+
 // -(main)--------------------------------------------------
 int main(void)
 {
@@ -114,7 +125,7 @@ int main(void)
     CLASS_ATTR_OBJ(c, "sig_ptr", ATTR_GET_OPAQUE_USER | ATTR_SET_OPAQUE_USER, t_mpr_in, sig_ptr);
     CLASS_ATTR_ACCESSORS(c, "sig_ptr", 0, set_sig_ptr);
 
-    CLASS_ATTR_LONG(c, "instance", 0, t_mpr_in, instance_id);
+    CLASS_ATTR_ATOM_LONG(c, "instance", 0, t_mpr_in, instance_id);
     CLASS_ATTR_ACCESSORS(c, "instance", mpr_in_instance_get, mpr_in_instance_set);
 
     class_register(CLASS_BOX, c); /* CLASS_NOBOX */
@@ -389,23 +400,25 @@ void parse_extra_properties(t_mpr_in *x, int argc, t_atom *argv)
             }
             switch (x->sig_type) {
                 case 'i': {
-                    int val[x->sig_length];
+                    int* val = malloc(x->sig_length * sizeof(int));
                     for (j = 0, k = 0; j < x->sig_length; j++, k++) {
                         if (k >= length)
                             k = 0;
                         val[j] = atom_coerce_int(argv + i + k);
                     }
                     mpr_obj_set_prop(x->sig_ptr, extremum, NULL, x->sig_length, MPR_INT32, val, 1);
+                    free(val);
                     break;
                 }
                 case 'f': {
-                    float val[x->sig_length];
+                    float *val = malloc(x->sig_length * sizeof(float));
                     for (j = 0, k = 0; j < x->sig_length; j++, k++) {
                         if (k >= length)
                             k = 0;
                         val[j] = atom_coerce_float(argv + i + k);
                     }
                     mpr_obj_set_prop(x->sig_ptr, extremum, NULL, x->sig_length, MPR_FLT, val, 1);
+                    free(val);
                     break;
                 }
                 default:
@@ -420,25 +433,28 @@ void parse_extra_properties(t_mpr_in *x, int argc, t_atom *argv)
                         mpr_obj_set_prop(x->sig_ptr, MPR_PROP_UNKNOWN, prop_name, 1, MPR_STR, value, 1);
                     }
                     else {
-                        const char *value[length];
+                        char *value = malloc(length);
                         for (j = 0; j < length; j++)
                             value[j] = atom_get_string(argv + i + j);
                         mpr_obj_set_prop(x->sig_ptr, MPR_PROP_UNKNOWN, prop_name, length, MPR_STR, &value, 1);
+                        free(value);
                     }
                     break;
                 }
                 case A_FLOAT: {
-                    float value[length];
+                    float *value = malloc(length * sizeof(float));
                     for (j = 0; j < length; j++)
                         value[j] = atom_coerce_float(argv + i + j);
                     mpr_obj_set_prop(x->sig_ptr, MPR_PROP_UNKNOWN, prop_name, length, MPR_FLT, value, 1);
+                    free(value);
                     break;
                 }
                 case A_LONG: {
-                    int value[length];
+                    int *value = malloc(length * sizeof(int));
                     for (j = 0; j < length; j++)
                         value[j] = atom_coerce_int(argv + i + j);
                     mpr_obj_set_prop(x->sig_ptr, MPR_PROP_UNKNOWN, prop_name, length, MPR_INT32, value, 1);
+                    free(value);
                     break;
                 }
                 default:
@@ -529,7 +545,7 @@ static void mpr_in_list(t_mpr_in *x, t_symbol *s, int argc, t_atom *argv)
     }
 
     if (x->type == 'i') {
-        int payload[argc];
+        int *payload = malloc(argc * sizeof(int));
         value = &payload;
         for (i = 0; i < argc; i++) {
             if ((argv+i)->a_type == A_FLOAT)
@@ -538,6 +554,7 @@ static void mpr_in_list(t_mpr_in *x, t_symbol *s, int argc, t_atom *argv)
                 payload[i] = (int)atom_getlong(argv+i);
             else {
                 object_post((t_object *)x, "Illegal data type in list!");
+                free(payload);
                 return;
             }
         }
@@ -545,9 +562,10 @@ static void mpr_in_list(t_mpr_in *x, t_symbol *s, int argc, t_atom *argv)
         critical_enter(0);
         mpr_sig_set_value(x->sig_ptr, x->instance_id, argc, MPR_INT32, value);
         critical_exit(0);
+        free(payload);
     }
     else if (x->type == 'f') {
-        float payload[argc];
+        float *payload = malloc(argc * sizeof(float));
         value = &payload;
         for (i = 0; i < argc; i++) {
             if ((argv+i)->a_type == A_FLOAT)
@@ -556,6 +574,7 @@ static void mpr_in_list(t_mpr_in *x, t_symbol *s, int argc, t_atom *argv)
                 payload[i] = (float)atom_getlong(argv+i);
             else {
                 object_post((t_object *)x, "Illegal data type in list!");
+                free(payload);
                 return;
             }
         }
@@ -563,6 +582,7 @@ static void mpr_in_list(t_mpr_in *x, t_symbol *s, int argc, t_atom *argv)
         critical_enter(0);
         mpr_sig_set_value(x->sig_ptr, x->instance_id, argc, MPR_FLT, value);
         critical_exit(0);
+        free(payload);
     }
 }
 


### PR DESCRIPTION
C90 compatible changes for mpr.in/out (variable length arrays changed to malloc / free)

CLASS_ATTR_LONG changed to CLASS_ATTR_ATOM_LONG for instance_id since in Win64 a long is only 4 bytes (may need further verification this change doesn't have any unintentional consequences).

Some #ifdefs for Windows-specific settings, including addition of ext_main function which appears to be [necessary for Windows](https://cycling74.com/sdk/max-sdk-7.3.3/html/chapter_platform.html#chapter_platform_win).

Briefly tested and it seems to compile and run fine in OSX with these changes.

[Compiled test package available here](https://github.com/johnty/mapper-max-pd/releases/tag/20210512)